### PR TITLE
Setup RALLY_POSTGRES and RALLY_MYSQL via single env variable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -428,7 +428,7 @@
       sed -i 's|^.*glance_image_create_timeout.*$|glance_image_create_timeout=600|' /etc/rally/rally.conf
       ln -s ${VENV}/bin/rally /usr/local/bin/
       ln -s ${VENV}/bin/rally-manage /usr/local/bin/
-      if [ -n "${RALLY_POSTGRES}" ]; then
+      if [[ ${RALLY_EXTRAS} == *"postgres"* ]]; then
         unset LANG
         unset ${!LC_*}
         apt-get update && apt-get --force-yes -y install postgresql
@@ -437,7 +437,7 @@
         sed -i 's|#connection *=.*|connection=postgresql+psycopg2:///rally?host=/var/run/postgresql|' /etc/rally/rally.conf
         $RCI_PYTHON -m pip install psycopg2
       fi
-      if [ -n "${RALLY_MYSQL}" ]; then
+      if [[ ${RALLY_EXTRAS} == *"mysql"* ]]; then
         unset LANG
         unset ${!LC_*}
         echo "mysql-server mysql-server/root_password password r00tme" | debconf-set-selections
@@ -901,7 +901,7 @@
     timeout: 180
     env:
       RCI_PYTHON: python2.7
-      RALLY_POSTGRES: 1
+      RALLY_EXTRAS: postgres
     provider: ci4950
     vms:
       - name: u1404_dsvm_2
@@ -923,7 +923,7 @@
     timeout: 180
     env:
       RCI_PYTHON: python2.7
-      RALLY_POSTGRES: 1
+      RALLY_EXTRAS: postgres
     provider: ci4950
     vms:
       - name: u1604_dsvm
@@ -945,7 +945,7 @@
     timeout: 120
     env:
       RCI_PYTHON: python3
-      RALLY_POSTGRES: 1
+      RALLY_EXTRAS: postgres
     provider: ci4950
     vms:
       - name: u1604_dsvm
@@ -986,7 +986,7 @@
     name: rally-pg-py27-unit
     env:
       TOX_ENV: py27
-      RALLY_POSTGRES: 1
+      RALLY_EXTRAS: postgres
       RALLY_UNITTEST_DB_URL: "postgresql:///rally?host=/var/run/postgresql"
     provider: ci4950
     vms:
@@ -1000,7 +1000,7 @@
     name: rally-mysql-py27-unit
     env:
       TOX_ENV: py27
-      RALLY_MYSQL: 1
+      RALLY_EXTRAS: mysql
       RALLY_UNITTEST_DB_URL: "mysql://rally:rally@localhost/rally"
     provider: ci4950
     vms:


### PR DESCRIPTION
Python tox can handle extra requirements of a project(e.g psycopg2 and
PyMySQL), but we need to trigger it. RALLY_EXTRAS environment variable
is used there for such behaviour. To not duplicate several variables
with similar values, let's merge RALLY_POSTGRES and RALLY_MYSQL into a
single RALLY_EXTRAS .