### PR TITLE
Remove rally-manage db recreate check for container

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -304,7 +304,6 @@
       docker build -t rallyforge/rally .
       mkdir /tmp/rv
       sudo chown 65500 /tmp/rv
-      docker run -v /tmp/rv:/home/rally rallyforge/rally rally-manage db recreate
       docker run -v /tmp/rv:/home/rally rallyforge/rally rally deployment create --name EX --file /opt/rally/samples/deployments/existing.json
       docker run -v /tmp/rv:/home/rally rallyforge/rally rally deployment list
       docker run -v /tmp/rv:/home/rally rallyforge/rally rally version


### PR DESCRIPTION
This is no need anymore because it works automatically now
https://review.openstack.org/#/c/497823/