### PR TITLE
Fix docker rally container commands

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -304,10 +304,9 @@
       docker build -t rallyforge/rally .
       mkdir /tmp/rv
       sudo chown 65500 /tmp/rv
-      docker run -v /tmp/rv:/home/rally rallyforge/rally rally deployment create --name EX --file /opt/rally/samples/deployments/existing.json
-      docker run -v /tmp/rv:/home/rally rallyforge/rally rally deployment list
-      docker run -v /tmp/rv:/home/rally rallyforge/rally rally version
-      #docker run -v /tmp/rv:/home/rally rallyforge/rally rally verify install
+      docker run -v /tmp/rv:/home/rally rallyforge/rally deployment create --name EX --file /opt/rally/samples/deployments/existing.json
+      docker run -v /tmp/rv:/home/rally rallyforge/rally deployment list
+      docker run -v /tmp/rv:/home/rally rallyforge/rally version
 
 - script:
     name: pull_ubuntu_1404


### PR DESCRIPTION
Now we use entrypoint which means that we don't specify rally command anymore